### PR TITLE
Keep last last_path if input files is empty rather than throw an exception

### DIFF
--- a/src/main/java/org/embulk/input/gcs/GcsFileInputPlugin.java
+++ b/src/main/java/org/embulk/input/gcs/GcsFileInputPlugin.java
@@ -105,13 +105,20 @@ public class GcsFileInputPlugin
 
         control.run(taskSource, taskCount);
 
+        ConfigDiff configDiff = Exec.newConfigDiff();
+
         List<String> files = new ArrayList<String>(task.getFiles());
-        if (files.size() == 0) {
-            return null;
+        if (files.isEmpty()) {
+            // keep the last value if any
+            if (task.getLastPath().isPresent()) {
+                configDiff.set("last_path", task.getLastPath().get());
+            }
+        } else {
+            Collections.sort(files);
+            configDiff.set("last_path", files.get(files.size() - 1));
         }
-        Collections.sort(files);
-        return Exec.newConfigDiff().
-                set("last_path", files.get(files.size() - 1));
+
+        return configDiff;
     }
 
     @Override


### PR DESCRIPTION
If input file path list is empty, resume() throws an exception at `files.get(files.size() - 1)`. However, it is possible when there are no uploaded files during scheduled time period of bulk import executions.
This pull-request fixes it by keeping the last `last_path` if the input file list is empty.
