### PR TITLE
Accept local file content in config file as well as file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ embulk run /path/to/config.yml
 - **path_prefix** prefix of target keys (string, required)
 - **auth_method**  (string, optional, "private_key" or "compute_engine". default value is "private_key")
 - **service_account_email** Google Cloud Storage service_account_email (string, required)
-- **p12_keyfile_fullpath** fullpath of p12 key (string, required)
+- **p12_keyfile** fullpath of p12 key (string, required)
 - **application_name** application name anything you like (string, optional)
 
 ## Example
@@ -54,7 +54,7 @@ in:
   path_prefix: logs/csv-
   auth_method: private_key #default
   service_account_email: ABCXYZ123ABCXYZ123.gserviceaccount.com
-  p12_keyfile_path: /path/to/p12_keyfile.p12
+  p12_keyfile: /path/to/p12_keyfile.p12
   application_name: Anything you like
 ```
 
@@ -67,7 +67,7 @@ in:
   path_prefix: sample_
   auth_method: private_key #default
   service_account_email: ABCXYZ123ABCXYZ123.gserviceaccount.com
-  p12_keyfile_path: /path/to/p12_keyfile.p12
+  p12_keyfile: /path/to/p12_keyfile.p12
   application_name: Anything you like
   decoders:
   - {type: gzip}


### PR DESCRIPTION
This pull request is same as https://github.com/embulk/embulk-output-bigquery/pull/13

```
Embulk supports distributed executors such as embulk-executor-mapreduce.
Those executors run tasks on remote server. Including local file path in
TaskSource may task filed on remote server because the file is not
there.

org.embulk.spi.unit.LocalFile is added since embulk v0.6.16 to solve
this problem. It reads content from the local file path when it's
initialized.

It also accepts embedding content of a file in config file.
```
