### PR TITLE
Add paths option to support strong consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ embulk run /path/to/config.yml
 ## Configuration
 
 - **bucket** Google Cloud Storage bucket name (string, required)
-- **path_prefix** prefix of target keys (string, required)
+- **path_prefix** prefix of target keys (string, either of "path_prefix" or "paths" is required)
+- **paths** list of target keys (array of string, either of "path_prefix" or "paths" is required)
 - **auth_method**  (string, optional, "private_key", "json_key" or "compute_engine". default value is "private_key")
 - **service_account_email** Google Cloud Storage service_account_email (string, required when auth_method is private_key)
 - **p12_keyfile** fullpath of p12 key (string, required when auth_method is private_key)
@@ -146,6 +147,13 @@ in:
   type: gcs
   auth_method: compute_engine
 ```
+
+## Eventually Consistency
+
+An operation listing objects is eventually consistent although getting objects is strongly consistent, see https://cloud.google.com/storage/docs/consistency.
+
+`path_prefix` uses the objects list API, therefore it would miss some of objects.
+If you want to avoid such situations, you should use `paths` option which directly specifies object paths without the objects list API.
 
 ## Build
 

--- a/src/test/java/org/embulk/input/gcs/TestGcsFileInputPlugin.java
+++ b/src/test/java/org/embulk/input/gcs/TestGcsFileInputPlugin.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assume.assumeNotNull;
 
 import java.lang.reflect.InvocationTargetException;
@@ -105,6 +106,38 @@ public class TestGcsFileInputPlugin
         GcsFileInputPlugin.PluginTask task = config.loadConfig(PluginTask.class);
         assertEquals("private_key", task.getAuthMethod().toString());
         assertEquals("Embulk GCS input plugin", task.getApplicationName());
+    }
+
+    // paths are set
+    @Test
+    public void checkDefaultValuesPathsSpecified()
+    {
+        ConfigSource config = Exec.newConfigSource()
+                .set("bucket", GCP_BUCKET)
+                .set("paths", "{\"object1\",\"object2\"}")
+                .set("auth_method", "private_key")
+                .set("service_account_email", GCP_EMAIL)
+                .set("p12_keyfile", GCP_P12_KEYFILE)
+                .set("p12_keyfile_fullpath", GCP_P12_KEYFILE)
+                .set("parser", parserConfig(schemaConfig()));
+
+        GcsFileInputPlugin.PluginTask task = config.loadConfig(PluginTask.class);
+        assertFalse(task.getFiles().isEmpty());
+    }
+
+    // both path_prefix and paths are not set
+    @Test(expected = ConfigException.class)
+    public void checkDefaultValuesNoPathSpecified()
+    {
+        ConfigSource config = Exec.newConfigSource()
+                .set("bucket", GCP_BUCKET)
+                .set("auth_method", "private_key")
+                .set("service_account_email", GCP_EMAIL)
+                .set("p12_keyfile", GCP_P12_KEYFILE)
+                .set("p12_keyfile_fullpath", GCP_P12_KEYFILE)
+                .set("parser", parserConfig(schemaConfig()));
+
+        runner.transaction(config, new Control());
     }
 
     // p12_keyfile is null when auth_method is private_key


### PR DESCRIPTION
Fix https://github.com/embulk/embulk-input-gcs/issues/16

Added an option to specify object paths directly instead of `path_prefix`
