### PR TITLE
[WIP] Fix retry logic to handle some type of Exceptions expectedly

### DIFF
--- a/src/main/java/org/embulk/input/gcs/GcsFileInputPlugin.java
+++ b/src/main/java/org/embulk/input/gcs/GcsFileInputPlugin.java
@@ -327,11 +327,16 @@ public class GcsFileInputPlugin
                     .withMaxRetryWait(30 * 1000)
                     .runInterruptible(new Retryable<InputStream>() {
                         @Override
-                        public InputStream call() throws InterruptedIOException, IOException
+                        public InputStream call() throws InterruptedIOException
                         {
                             log.warn(String.format("GCS read failed. Retrying GET request with %,d bytes offset", offset), closedCause);
-                            Storage.Objects.Get getObject = client.objects().get(bucket, key);
-                            return getObject.executeMediaAsInputStream();
+                            try {
+                                Storage.Objects.Get getObject = client.objects().get(bucket, key);
+                                return getObject.executeMediaAsInputStream();
+                            }
+                            catch (IOException ex) {
+                                throw Throwables.propagate(ex);
+                            }
                         }
 
                         @Override


### PR DESCRIPTION
v0.2.0 seems to fail to handle some types of Exception like 'javax.net.ssl.SSLException'.
This failure was reported at #20.

I fixed it.
