### PR TITLE
Fix validation logic for 'path_prefix' and 'paths' options

### DIFF
--- a/src/main/java/org/embulk/input/gcs/GcsFileInputPlugin.java
+++ b/src/main/java/org/embulk/input/gcs/GcsFileInputPlugin.java
@@ -142,8 +142,10 @@ public class GcsFileInputPlugin
         if (task.getPathPrefix().isPresent()) {
             task.setFiles(listFiles(task, client));
         }
-        if (task.getFiles().isEmpty()) {
-            throw new ConfigException("No file is found. Fix path_prefix or specify paths directly");
+        else {
+            if (task.getFiles().isEmpty()) {
+                throw new ConfigException("No file is found. Confirm paths option isn't empty");
+            }
         }
         // number of processors is same with number of files
         return resume(task.dump(), task.getFiles().size(), control);

--- a/src/test/java/org/embulk/input/gcs/TestGcsFileInputPlugin.java
+++ b/src/test/java/org/embulk/input/gcs/TestGcsFileInputPlugin.java
@@ -316,6 +316,42 @@ public class TestGcsFileInputPlugin
     }
 
     @Test
+    public void testNonExistingFilesWithPathPrefix() throws Exception
+    {
+        ConfigSource config = Exec.newConfigSource()
+                .set("bucket", GCP_BUCKET)
+                .set("path_prefix", "/path/to/notfound")
+                .set("auth_method", "private_key")
+                .set("service_account_email", GCP_EMAIL)
+                .set("p12_keyfile", GCP_P12_KEYFILE)
+                .set("json_keyfile", GCP_JSON_KEYFILE)
+                .set("application_name", GCP_APPLICATION_NAME)
+                .set("last_path", "")
+                .set("parser", parserConfig(schemaConfig()));
+
+        ConfigDiff configDiff = runner.transaction(config, new Control());
+
+        assertEquals("", configDiff.get(String.class, "last_path"));
+    }
+
+    @Test(expected = ConfigException.class)
+    public void testNonExistingFilesWithPaths() throws Exception
+    {
+        ConfigSource config = Exec.newConfigSource()
+                .set("bucket", GCP_BUCKET)
+                .set("paths", Arrays.asList())
+                .set("auth_method", "private_key")
+                .set("service_account_email", GCP_EMAIL)
+                .set("p12_keyfile", GCP_P12_KEYFILE)
+                .set("json_keyfile", GCP_JSON_KEYFILE)
+                .set("application_name", GCP_APPLICATION_NAME)
+                .set("last_path", "")
+                .set("parser", parserConfig(schemaConfig()));
+
+        runner.transaction(config, new Control());
+    }
+
+    @Test
     public void testGcsFileInputByOpen()
             throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, IOException
     {


### PR DESCRIPTION
I found different behavior between **embulk-input-s3** and this plugin.

In case of 'path_prefix' isn't empty and file doesn't exists at remote bucket, both plugin works...
## Actual behavior

``` yaml
# example config file
in:
  type: gcs
  bucket: big-query-test
  path_prefix: /path/to/notfound
```
### embulk-input-s3

task was commited and no Exception happened.

``` shell
$ embulk run s3_config.yml
...
2016-08-08 15:10:56.003 +0900 [INFO] (main): Committed.
2016-08-08 15:10:56.005 +0900 [INFO] (main): Next config diff: {"in":{"last_path":null},"out":{}}
```
### embulk-input-gcs

ConfigException was thrown.

``` shell
Error: org.embulk.config.ConfigException: No file is found. Fix path_prefix or specify paths directly
```
## My implementation

I changed code as following.
- using `path_prefix` option
  - No Exception will be thrown even if no file exists at remote bucket.
- using `paths` option
  - Throw ConfigException if no file exists at remote bucket.
