### PR TITLE
Support incremental flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ embulk run /path/to/config.yml
 - **bucket** Google Cloud Storage bucket name (string, required)
 - **path_prefix** prefix of target keys (string, either of "path_prefix" or "paths" is required)
 - **paths** list of target keys (array of string, either of "path_prefix" or "paths" is required)
+- **incremental**: enables incremental loading(boolean, optional. default: true. If incremental loading is enabled, config diff for the next execution will include `last_path` parameter so that next execution skips files before the path. Otherwise, `last_path` will not be included.
 - **auth_method**  (string, optional, "private_key", "json_key" or "compute_engine". default value is "private_key")
 - **service_account_email** Google Cloud Storage service_account_email (string, required when auth_method is private_key)
 - **p12_keyfile** fullpath of p12 key (string, required when auth_method is private_key)

--- a/src/main/java/org/embulk/input/gcs/GcsFileInputPlugin.java
+++ b/src/main/java/org/embulk/input/gcs/GcsFileInputPlugin.java
@@ -59,6 +59,10 @@ public class GcsFileInputPlugin
         @ConfigDefault("null")
         Optional<String> getLastPath();
 
+        @Config("incremental")
+        @ConfigDefault("true")
+        boolean getIncremental();
+
         @Config("auth_method")
         @ConfigDefault("\"private_key\"")
         AuthMethod getAuthMethod();
@@ -179,15 +183,17 @@ public class GcsFileInputPlugin
         ConfigDiff configDiff = Exec.newConfigDiff();
 
         List<String> files = new ArrayList<String>(task.getFiles());
-        if (files.isEmpty()) {
-            // keep the last value if any
-            if (task.getLastPath().isPresent()) {
-                configDiff.set("last_path", task.getLastPath().get());
+        if (task.getIncremental()) {
+            if (files.isEmpty()) {
+                // keep the last value if any
+                if (task.getLastPath().isPresent()) {
+                    configDiff.set("last_path", task.getLastPath().get());
+                }
             }
-        }
-        else {
-            Collections.sort(files);
-            configDiff.set("last_path", files.get(files.size() - 1));
+            else {
+                Collections.sort(files);
+                configDiff.set("last_path", files.get(files.size() - 1));
+            }
         }
 
         return configDiff;

--- a/src/test/java/org/embulk/input/gcs/TestGcsFileInputPlugin.java
+++ b/src/test/java/org/embulk/input/gcs/TestGcsFileInputPlugin.java
@@ -105,6 +105,7 @@ public class TestGcsFileInputPlugin
                 .set("path_prefix", "my-prefix");
 
         GcsFileInputPlugin.PluginTask task = config.loadConfig(PluginTask.class);
+        assertEquals(true, task.getIncremental());
         assertEquals("private_key", task.getAuthMethod().toString());
         assertEquals("Embulk GCS input plugin", task.getApplicationName());
     }
@@ -300,6 +301,17 @@ public class TestGcsFileInputPlugin
         List<String> actual = plugin.listGcsFilesByPrefix(client, GCP_BUCKET, GCP_PATH_PREFIX, Optional.<String>absent());
         assertEquals(expected, actual);
         assertEquals(GCP_BUCKET_DIRECTORY + "sample_02.csv", configDiff.get(String.class, "last_path"));
+    }
+
+    @Test
+    public void testListFilesByPrefixIncrementalFalse() throws Exception
+    {
+        ConfigSource config = config().deepCopy()
+                .set("incremental", false);
+
+        ConfigDiff configDiff = runner.transaction(config, new Control());
+
+        assertEquals("{}", configDiff.toString());
     }
 
     @Test


### PR DESCRIPTION
In this PR, I added `incremental` option. This option was already implemented at [embulk-input-s3](https://github.com/embulk/embulk-input-s3/) and works same.

We have a system that automates incremental data loading.
But some use cases don't need incremental data loading.

Instead, they load the entire data every time and replaces the data in the destination table every time. This flag controls the behavior.
