### PR TITLE
Fix inputStream handling to avoid plugin get less records than expected

### DIFF
--- a/src/test/java/org/embulk/input/gcs/TestGcsFileInputPlugin.java
+++ b/src/test/java/org/embulk/input/gcs/TestGcsFileInputPlugin.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 
 import java.io.BufferedReader;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -404,10 +405,11 @@ public class TestGcsFileInputPlugin
         Method method = GcsFileInputPlugin.class.getDeclaredMethod("newGcsAuth", PluginTask.class);
         method.setAccessible(true);
         Storage client = plugin.newGcsClient(task, (GcsAuthentication) method.invoke(plugin, task));
+        File tempFile = Exec.getTempFileSpace().createTempFile();
         task.setFiles(plugin.listFiles(task, client));
 
         String key = GCP_BUCKET_DIRECTORY + "sample_01.csv";
-        GcsFileInputPlugin.GcsInputStreamReopener opener = new GcsFileInputPlugin.GcsInputStreamReopener(client, GCP_BUCKET, key, MAX_CONNECTION_RETRY);
+        GcsFileInputPlugin.GcsInputStreamReopener opener = new GcsFileInputPlugin.GcsInputStreamReopener(tempFile, client, GCP_BUCKET, key, MAX_CONNECTION_RETRY);
         try (InputStream in = opener.reopen(0, new RuntimeException())) {
             BufferedReader r = new BufferedReader(new InputStreamReader(in));
             assertEquals("id,account,time,purchase,comment", r.readLine());


### PR DESCRIPTION
Plugin gets less records than expected infrequently.

Although reproduce condition isn't actually unclear, I can reproduce this problem with recent stored data. Problem doesn't happens with old stored data.

I changed implementation to write at local temporary file at first.
Then, plugin will create inputStream by reopening this temporary file and return it to Embulk.
