### PR TITLE
Fix retry logic to avoid IOException happens when IOUtils.coy()

### DIFF
--- a/src/test/java/org/embulk/input/gcs/TestGcsFileInputPlugin.java
+++ b/src/test/java/org/embulk/input/gcs/TestGcsFileInputPlugin.java
@@ -409,7 +409,7 @@ public class TestGcsFileInputPlugin
         task.setFiles(plugin.listFiles(task, client));
 
         String key = GCP_BUCKET_DIRECTORY + "sample_01.csv";
-        GcsFileInputPlugin.GcsInputStreamReopener opener = new GcsFileInputPlugin.GcsInputStreamReopener(tempFile, client, GCP_BUCKET, key, MAX_CONNECTION_RETRY);
+        GcsFileInputPlugin.GcsInputStreamReopener opener = new GcsFileInputPlugin.GcsInputStreamReopener(tempFile, client, GCP_BUCKET, key, MAX_CONNECTION_RETRY, null);
         try (InputStream in = opener.reopen(0, new RuntimeException())) {
             BufferedReader r = new BufferedReader(new InputStreamReader(in));
             assertEquals("id,account,time,purchase,comment", r.readLine());


### PR DESCRIPTION
I found minor problem with this plugin.
Plugin rarely fails to retry when IOException happens while `IOUtils.copy()`.
https://github.com/embulk/embulk-input-gcs/blob/v0.2.5/src/main/java/org/embulk/input/gcs/GcsFileInputPlugin.java#L447

This IOException is not retried by `org.embulk.spi.util.RetryExecutor`.
I changed retry logic to retry this type of failure.

### Stacktrace
```
Caused by: java.lang.RuntimeException: java.io.IOException: Connection closed prematurely: bytesRead = 8388608, Content-Length = 86774288 at 
org.embulk.spi.util.InputStreamFileInput.nextFile(InputStreamFileInput.java:170) at org.embulk.spi.util.FileInputInputStream.nextFile(FileInputInputStream.java:27) at 
org.embulk.standards.GzipFileDecoderPlugin$1.openNext(GzipFileDecoderPlugin.java:43) at org.embulk.spi.util.InputStreamFileInput.nextFile(InputStreamFileInput.java:167) at 
org.embulk.spi.util.FileInputInputStream.nextFile(FileInputInputStream.java:27) at org.embulk.spi.util.LineDecoder.nextFile(LineDecoder.java:52) at 
org.embulk.standards.CsvTokenizer.nextFile(CsvTokenizer.java:116) at org.embulk.standards.CsvParserPlugin.run(CsvParserPlugin.java:264) at 
org.embulk.spi.FileInputRunner.run(FileInputRunner.java:156) at org.embulk.spi.util.Executors.process(Executors.java:67) at 
org.embulk.spi.util.Executors.process(Executors.java:42) at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecutorPlugin.java:184) at 
org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecutorPlugin.java:180) at java.util.concurrent.FutureTask.run(FutureTask.java:266) at 
java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) at 
java.lang.Thread.run(Thread.java:748) Caused by: java.io.IOException: Connection closed prematurely: bytesRead = 8388608, Content-Length = 86774288 at 
com.google.api.client.http.javanet.NetHttpResponse$SizeValidatingInputStream.throwIfFalseEOF(NetHttpResponse.java:202) at 
com.google.api.client.http.javanet.NetHttpResponse$SizeValidatingInputStream.read(NetHttpResponse.java:171) at java.io.FilterInputStream.read(FilterInputStream.java:107) at 
com.google.api.client.util.ByteStreams.copy(ByteStreams.java:51) at com.google.api.client.util.IOUtils.copy(IOUtils.java:94) at 
com.google.api.client.util.IOUtils.copy(IOUtils.java:63) at org.embulk.input.gcs.GcsFileInputPlugin$SingleFileProvider.openNext(GcsFileInputPlugin.java:447) at 
org.embulk.spi.util.InputStreamFileInput.nextFile(InputStreamFileInput.java:167) ... 16 more >, elapsed=4964.246524532
```