### PR TITLE
Use host addon and set `dist:precise` to avoid Travis CI failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: precise
 language: java
 
 jdk:
@@ -21,3 +22,7 @@ env:
 script:
   - ./gradlew gem
   - ./gradlew --info check jacocoTestReport
+addons:
+  hosts:
+    - example.com
+  hostname: example.com


### PR DESCRIPTION
Use host addon & Set dist: precise for fixing tests. See the below refs.

ref. https://github.com/embulk/embulk-output-sftp/pull/38