### PR TITLE
Fix retry logic to avoid IOException happens while IOUtils.copy()

### DIFF
--- a/src/test/java/org/embulk/input/gcs/TestGcsFileInputPlugin.java
+++ b/src/test/java/org/embulk/input/gcs/TestGcsFileInputPlugin.java
@@ -24,12 +24,7 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.io.BufferedReader;
-
-import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -418,35 +413,6 @@ public class TestGcsFileInputPlugin
         task.setFiles(GcsFileInput.listFiles(task, client));
 
         assertRecords(config, output);
-    }
-
-    @Test
-    public void testGcsFileInputByReopen()
-            throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, IOException
-    {
-        ConfigSource config = Exec.newConfigSource()
-                .set("bucket", GCP_BUCKET)
-                .set("path_prefix", GCP_PATH_PREFIX)
-                .set("auth_method", "json_key")
-                .set("service_account_email", GCP_EMAIL)
-                .set("json_keyfile", GCP_JSON_KEYFILE)
-                .set("parser", parserConfig(schemaConfig()));
-
-        PluginTask task = config.loadConfig(PluginTask.class);
-        runner.transaction(config, new Control());
-
-        Method method = GcsFileInput.class.getDeclaredMethod("newGcsAuth", PluginTask.class);
-        method.setAccessible(true);
-        Storage client = GcsFileInput.newGcsClient(task, (GcsAuthentication) method.invoke(plugin, task));
-        File tempFile = Exec.getTempFileSpace().createTempFile();
-        task.setFiles(GcsFileInput.listFiles(task, client));
-
-        String key = GCP_BUCKET_DIRECTORY + "sample_01.csv";
-        SingleFileProvider.GcsInputStreamReopener opener = new SingleFileProvider.GcsInputStreamReopener(tempFile, client, GCP_BUCKET, key, MAX_CONNECTION_RETRY);
-        try (InputStream in = opener.reopen(0, new RuntimeException())) {
-            BufferedReader r = new BufferedReader(new InputStreamReader(in));
-            assertEquals("id,account,time,purchase,comment", r.readLine());
-        }
     }
 
     @Test


### PR DESCRIPTION
Revised #29 since I refactored code at #31 and code structure was changed.

Plugin rarely fails to retry when IOException happens while `IOUtils.copy()`.
https://github.com/embulk/embulk-input-gcs/blob/v0.2.6/src/main/java/org/embulk/input/gcs/SingleFileProvider.java#L56

This IOException is not retried by `org.embulk.spi.util.RetryExecutor`.
I changed retry logic to retry this type of failure.

### Stacktrace of v0.2.5
```
Caused by: java.lang.RuntimeException: java.io.IOException: Connection closed prematurely: bytesRead = 8388608, Content-Length = 86774288 at 
org.embulk.spi.util.InputStreamFileInput.nextFile(InputStreamFileInput.java:170) at org.embulk.spi.util.FileInputInputStream.nextFile(FileInputInputStream.java:27) at 
org.embulk.standards.GzipFileDecoderPlugin$1.openNext(GzipFileDecoderPlugin.java:43) at org.embulk.spi.util.InputStreamFileInput.nextFile(InputStreamFileInput.java:167) at 
org.embulk.spi.util.FileInputInputStream.nextFile(FileInputInputStream.java:27) at org.embulk.spi.util.LineDecoder.nextFile(LineDecoder.java:52) at 
org.embulk.standards.CsvTokenizer.nextFile(CsvTokenizer.java:116) at org.embulk.standards.CsvParserPlugin.run(CsvParserPlugin.java:264) at 
org.embulk.spi.FileInputRunner.run(FileInputRunner.java:156) at org.embulk.spi.util.Executors.process(Executors.java:67) at 
org.embulk.spi.util.Executors.process(Executors.java:42) at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecutorPlugin.java:184) at 
org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecutorPlugin.java:180) at java.util.concurrent.FutureTask.run(FutureTask.java:266) at 
java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) at 
java.lang.Thread.run(Thread.java:748) Caused by: java.io.IOException: Connection closed prematurely: bytesRead = 8388608, Content-Length = 86774288 at 
com.google.api.client.http.javanet.NetHttpResponse$SizeValidatingInputStream.throwIfFalseEOF(NetHttpResponse.java:202) at 
com.google.api.client.http.javanet.NetHttpResponse$SizeValidatingInputStream.read(NetHttpResponse.java:171) at java.io.FilterInputStream.read(FilterInputStream.java:107) at 
com.google.api.client.util.ByteStreams.copy(ByteStreams.java:51) at com.google.api.client.util.IOUtils.copy(IOUtils.java:94) at 
com.google.api.client.util.IOUtils.copy(IOUtils.java:63) at org.embulk.input.gcs.GcsFileInputPlugin$SingleFileProvider.openNext(GcsFileInputPlugin.java:447) at 
org.embulk.spi.util.InputStreamFileInput.nextFile(InputStreamFileInput.java:167) ... 16 more >, elapsed=4964.246524532
```