### PR TITLE
Only build for Java8 and fix Travis CI Failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
-dist: precise
 language: java
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
-  - openjdk7
 
 before_install:
   - openssl aes-256-cbc -K $encrypted_79f1af2a2546_key -iv $encrypted_79f1af2a2546_iv
@@ -22,7 +19,3 @@ env:
 script:
   - ./gradlew gem
   - ./gradlew --info check jacocoTestReport
-addons:
-  hosts:
-    - example.com
-  hostname: example.com

--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ configurations {
     provided
 }
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 version = "0.2.7"
 


### PR DESCRIPTION
Recently I got build failure only with Java7 at Travis CI. Build succeeded with Java8.
https://travis-ci.org/embulk/embulk-input-gcs/builds/398083351

Travis stopped to support Java7 and it's time to remove it from .travis.yml

Additionally, We're going to support Java8 with Embulk and its plugins. I updated build.gradle.