### PR TITLE
Update embulk version and use `java.util.Optional` and `java.util.function.Function`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,15 +20,15 @@ targetCompatibility = 1.8
 version = "0.2.8"
 
 dependencies {
-    compile  "org.embulk:embulk-core:0.8.2"
-    provided "org.embulk:embulk-core:0.8.2"
+    compile  "org.embulk:embulk-core:0.9.11"
+    provided "org.embulk:embulk-core:0.9.11"
 
     compile "com.google.http-client:google-http-client-jackson2:1.21.0"
     compile ("com.google.apis:google-api-services-storage:v1-rev59-1.21.0") {exclude module: "guava-jdk5"}
 
     testCompile "junit:junit:4.12"
-    testCompile "org.embulk:embulk-core:0.8.2:tests"
-    testCompile "org.embulk:embulk-standards:0.8.2"
+    testCompile "org.embulk:embulk-core:0.9.11:tests"
+    testCompile "org.embulk:embulk-standards:0.9.11"
 }
 
 task classpath(type: Copy, dependsOn: ["jar"]) {

--- a/src/main/java/org/embulk/input/gcs/FileList.java
+++ b/src/main/java/org/embulk/input/gcs/FileList.java
@@ -3,7 +3,6 @@ package org.embulk.input.gcs;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
@@ -21,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -176,7 +176,7 @@ public class FileList
             catch (IOException ex) {
                 throw Throwables.propagate(ex);
             }
-            return new FileList(binary.toByteArray(), getSplits(entries), Optional.fromNullable(last));
+            return new FileList(binary.toByteArray(), getSplits(entries), Optional.ofNullable(last));
         }
 
         private List<List<Entry>> getSplits(List<Entry> all)

--- a/src/main/java/org/embulk/input/gcs/GcsAuthentication.java
+++ b/src/main/java/org/embulk/input/gcs/GcsAuthentication.java
@@ -11,7 +11,6 @@ import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.storage.Storage;
 import com.google.api.services.storage.StorageScopes;
-import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import org.embulk.config.ConfigException;
@@ -28,6 +27,7 @@ import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
+import java.util.Optional;
 
 public class GcsAuthentication
 {
@@ -74,7 +74,7 @@ public class GcsAuthentication
         return new GoogleCredential.Builder()
                 .setTransport(httpTransport)
                 .setJsonFactory(jsonFactory)
-                .setServiceAccountId(serviceAccountEmail.orNull())
+                .setServiceAccountId(serviceAccountEmail.orElseGet(null))
                 .setServiceAccountScopes(
                         ImmutableList.of(
                                 StorageScopes.DEVSTORAGE_READ_ONLY

--- a/src/main/java/org/embulk/input/gcs/GcsFileInput.java
+++ b/src/main/java/org/embulk/input/gcs/GcsFileInput.java
@@ -6,8 +6,6 @@ import com.google.api.services.storage.model.Bucket;
 import com.google.api.services.storage.model.Objects;
 import com.google.api.services.storage.model.StorageObject;
 import com.google.common.base.Charsets;
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
 import com.google.common.io.BaseEncoding;
 import org.embulk.config.ConfigException;
 import org.embulk.config.TaskReport;
@@ -21,6 +19,8 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.security.GeneralSecurityException;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
 
 public class GcsFileInput
         extends InputStreamFileInput
@@ -53,8 +53,8 @@ public class GcsFileInput
             return new GcsAuthentication(
                     task.getAuthMethod().getString(),
                     task.getServiceAccountEmail(),
-                    task.getP12Keyfile().transform(localFileToPathString()),
-                    task.getJsonKeyfile().transform(localFileToPathString()),
+                    task.getP12Keyfile().map(localFileToPathString()),
+                    task.getJsonKeyfile().map(localFileToPathString()),
                     task.getApplicationName()
             );
         }

--- a/src/main/java/org/embulk/input/gcs/GcsFileInputPlugin.java
+++ b/src/main/java/org/embulk/input/gcs/GcsFileInputPlugin.java
@@ -1,8 +1,6 @@
 package org.embulk.input.gcs;
 
 import com.google.api.services.storage.Storage;
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigException;
@@ -18,6 +16,8 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
 
 public class GcsFileInputPlugin
         implements FileInputPlugin
@@ -86,8 +86,8 @@ public class GcsFileInputPlugin
             return new GcsAuthentication(
                     task.getAuthMethod().getString(),
                     task.getServiceAccountEmail(),
-                    task.getP12Keyfile().transform(localFileToPathString()),
-                    task.getJsonKeyfile().transform(localFileToPathString()),
+                    task.getP12Keyfile().map(localFileToPathString()),
+                    task.getJsonKeyfile().map(localFileToPathString()),
                     task.getApplicationName()
             );
         }

--- a/src/main/java/org/embulk/input/gcs/PluginTask.java
+++ b/src/main/java/org/embulk/input/gcs/PluginTask.java
@@ -1,6 +1,5 @@
 package org.embulk.input.gcs;
 
-import com.google.common.base.Optional;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigInject;
@@ -9,6 +8,7 @@ import org.embulk.spi.BufferAllocator;
 import org.embulk.spi.unit.LocalFile;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PluginTask
         extends Task, FileList.Task

--- a/src/test/java/org/embulk/input/gcs/TestGcsAuthentication.java
+++ b/src/test/java/org/embulk/input/gcs/TestGcsAuthentication.java
@@ -2,7 +2,6 @@ package org.embulk.input.gcs;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.services.storage.Storage;
-import com.google.common.base.Optional;
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigException;
 import org.junit.BeforeClass;
@@ -14,6 +13,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.security.GeneralSecurityException;
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeNotNull;

--- a/src/test/java/org/embulk/input/gcs/TestGcsFileInputPlugin.java
+++ b/src/test/java/org/embulk/input/gcs/TestGcsFileInputPlugin.java
@@ -1,7 +1,6 @@
 package org.embulk.input.gcs;
 
 import com.google.api.services.storage.Storage;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -29,6 +28,7 @@ import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeNotNull;
@@ -295,7 +295,7 @@ public class TestGcsFileInputPlugin
         method.setAccessible(true);
         Storage client = GcsFileInput.newGcsClient(task, (GcsAuthentication) method.invoke(plugin, task));
         FileList.Builder builder = new FileList.Builder(config);
-        GcsFileInput.listGcsFilesByPrefix(builder, client, GCP_BUCKET, GCP_PATH_PREFIX, Optional.<String>absent());
+        GcsFileInput.listGcsFilesByPrefix(builder, client, GCP_BUCKET, GCP_PATH_PREFIX, Optional.empty());
         FileList fileList = builder.build();
         assertEquals(expected.get(0), fileList.get(0).get(0));
         assertEquals(expected.get(1), fileList.get(1).get(0));
@@ -325,7 +325,7 @@ public class TestGcsFileInputPlugin
         method.setAccessible(true);
         Storage client = GcsFileInput.newGcsClient(task, (GcsAuthentication) method.invoke(plugin, task));
         FileList.Builder builder = new FileList.Builder(configWithPattern);
-        GcsFileInput.listGcsFilesByPrefix(builder, client, GCP_BUCKET, GCP_PATH_PREFIX, Optional.<String>absent());
+        GcsFileInput.listGcsFilesByPrefix(builder, client, GCP_BUCKET, GCP_PATH_PREFIX, Optional.empty());
         FileList fileList = builder.build();
         assertEquals(expected.get(0), fileList.get(0).get(0));
         assertEquals(GCP_BUCKET_DIRECTORY + "sample_01.csv", configDiff.get(String.class, "last_path"));
@@ -353,7 +353,7 @@ public class TestGcsFileInputPlugin
         method.setAccessible(true);
         Storage client = GcsFileInput.newGcsClient(task, (GcsAuthentication) method.invoke(plugin, task));
         FileList.Builder builder = new FileList.Builder(config);
-        GcsFileInput.listGcsFilesByPrefix(builder, client, "non-exists-bucket", "prefix", Optional.<String>absent()); // no errors happens
+        GcsFileInput.listGcsFilesByPrefix(builder, client, "non-exists-bucket", "prefix", Optional.empty()); // no errors happens
     }
 
     @Test


### PR DESCRIPTION
Same with https://github.com/embulk/embulk-input-sftp/pull/36

* Update Embulk version from 0.8.2 to 0.9.11
* Use `java.util.Optional` and `java.util.function.Function` instead of `com.google.common.base.Optional` and `com.google.common.base.Function`
  * Recent version of Embulk use `java.util.Optional`
* minor fix for logging - show key file path instead of unclear message