### PR TITLE
enhance base64 encode method to support Japanese character

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
 
+dist: trusty
+
 jdk:
   - oraclejdk8
 

--- a/src/main/java/org/embulk/input/gcs/GcsFileInput.java
+++ b/src/main/java/org/embulk/input/gcs/GcsFileInput.java
@@ -90,7 +90,7 @@ public class GcsFileInput
 
         int utf8EncodeLength = utf8.length;
         if (utf8EncodeLength >= 128) {
-            throw new ConfigException("Can't support last path encode length longer than 127. Please try to reduce the length");
+            throw new ConfigException(String.format("last_path '%s' is too long to encode. Please try to reduce its length", path));
         }
 
         encoding = new byte[utf8.length + 2];

--- a/src/test/java/org/embulk/input/gcs/TestGcsFileInputPlugin.java
+++ b/src/test/java/org/embulk/input/gcs/TestGcsFileInputPlugin.java
@@ -357,7 +357,7 @@ public class TestGcsFileInputPlugin
                 .set("p12_keyfile", GCP_P12_KEYFILE)
                 .set("json_keyfile", GCP_JSON_KEYFILE)
                 .set("application_name", GCP_APPLICATION_NAME)
-                .set("last_path", "テストシフト表/日日日日日aaaaaaaaaaaaa日日日日日日日日日日日日日日日日怠怠怠怠怠怠怠チェック_01067csv.csv")
+                .set("last_path", "テストダミー/テストダミーテストダミーテストダミーテストダミーテストダミーテストダミーテストダミー.csv")
                 .set("parser", parserConfig(schemaConfig()));
 
         runner.transaction(config, new Control());
@@ -393,8 +393,8 @@ public class TestGcsFileInputPlugin
         String expected = "Cn9jY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjMTI3";
         assertEquals(expected, GcsFileInput.base64Encode(params));
 
-        params = "テストシフト表/怠怠チェッ.csv";
-        expected = "Cinjg4bjgrnjg4jjgrfjg5Xjg4jooagv5oCg5oCg44OB44Kn44ODLmNzdg==";
+        params = "テストダミー/テス123/テストダミー/テストダミ.csv";
+        expected = "CkPjg4bjgrnjg4jjg4Djg5/jg7wv44OG44K5MTIzL+ODhuOCueODiOODgOODn+ODvC/jg4bjgrnjg4jjg4Djg58uY3N2";
         assertEquals(expected, GcsFileInput.base64Encode(params));
     }
 

--- a/src/test/java/org/embulk/input/gcs/TestGcsFileInputPlugin.java
+++ b/src/test/java/org/embulk/input/gcs/TestGcsFileInputPlugin.java
@@ -346,6 +346,23 @@ public class TestGcsFileInputPlugin
         runner.transaction(config, new Control());
     }
 
+    @Test(expected = ConfigException.class)
+    public void testLastPathTooLong() throws Exception
+    {
+        ConfigSource config = Exec.newConfigSource()
+                .set("bucket", GCP_BUCKET)
+                .set("paths", Arrays.asList())
+                .set("auth_method", "private_key")
+                .set("service_account_email", GCP_EMAIL)
+                .set("p12_keyfile", GCP_P12_KEYFILE)
+                .set("json_keyfile", GCP_JSON_KEYFILE)
+                .set("application_name", GCP_APPLICATION_NAME)
+                .set("last_path", "テストシフト表/日日日日日aaaaaaaaaaaaa日日日日日日日日日日日日日日日日怠怠怠怠怠怠怠チェック_01067csv.csv")
+                .set("parser", parserConfig(schemaConfig()));
+
+        runner.transaction(config, new Control());
+    }
+
     @Test
     public void testGcsFileInputByOpen()
     {
@@ -374,6 +391,10 @@ public class TestGcsFileInputPlugin
         assertEquals("ChZnY3MtdGVzdC9zYW1wbGVfMDEuY3N2", GcsFileInput.base64Encode("gcs-test/sample_01.csv"));
         String params = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc127";
         String expected = "Cn9jY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjMTI3";
+        assertEquals(expected, GcsFileInput.base64Encode(params));
+
+        params = "テストシフト表/怠怠チェッ.csv";
+        expected = "Cinjg4bjgrnjg4jjgrfjg5Xjg4jooagv5oCg5oCg44OB44Kn44ODLmNzdg==";
         assertEquals(expected, GcsFileInput.base64Encode(params));
     }
 


### PR DESCRIPTION
Because the file name and folder could be Japanese chars, which take 2-3-4 bytes when encoding to UTF-8. We should update the encodeBase64 method to support them as well.  