### PR TITLE
Disable publishing a Gradle Module Metadata in 0.4.1-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 group = "org.embulk"
-version = "0.4.0-SNAPSHOT"
+version = "0.4.1-SNAPSHOT"
 description = "Reads files stored on Google Cloud Storage."
 
 tasks.withType(JavaCompile) {
@@ -131,6 +131,12 @@ sourcesJar {
 javadocJar {
     from rootProject.file("LICENSE")
     from rootProject.file("NOTICE")
+}
+
+// It should not publish a `.module` file in Maven Central.
+// https://docs.gradle.org/current/userguide/publishing_gradle_module_metadata.html#sub:disabling-gmm-publication
+tasks.withType(GenerateModuleMetadata) {
+    enabled = false
 }
 
 publishing {


### PR DESCRIPTION
https://docs.gradle.org/current/userguide/publishing_gradle_module_metadata.html#sub:disabling-gmm-publication