### PR TITLE
Use varint length field for last_path encoding to support longer GCP object names

### DIFF
--- a/src/main/java/org/embulk/input/gcs/GcsFileInput.java
+++ b/src/main/java/org/embulk/input/gcs/GcsFileInput.java
@@ -116,7 +116,7 @@ public class GcsFileInput extends InputStreamFileInput implements TransactionalF
     }
 
     // see: https://protobuf.dev/programming-guides/encoding/#varints
-    private static byte[] encodeVarint(int value) {
+    static byte[] encodeVarint(int value) {
         // utf8EncodeLength.length is up to 65535, so 2 bytes are enough for buffer
         byte[] buffer = new byte[2];
         int pos = 0;

--- a/src/main/java/org/embulk/input/gcs/GcsFileInput.java
+++ b/src/main/java/org/embulk/input/gcs/GcsFileInput.java
@@ -91,8 +91,6 @@ public class GcsFileInput extends InputStreamFileInput implements TransactionalF
 
     // String nextToken = base64Encode(0x0a + ASCII character according to utf8EncodeLength position+ filePath);
     static String base64Encode(final String path) {
-        byte[] lengthVarint;
-        byte[] encoding;
         byte[] utf8 = path.getBytes(StandardCharsets.UTF_8);
         LOG.debug("path string: {} ,path length:{} \" + ", path, utf8.length);
 
@@ -103,6 +101,8 @@ public class GcsFileInput extends InputStreamFileInput implements TransactionalF
             throw new ConfigException(String.format("last_path '%s' is too long to encode. Maximum allowed is 1024 bytes", path));
         }
 
+        byte[] lengthVarint;
+        byte[] encoding;
         lengthVarint = encodeVarint(utf8EncodeLength);
         encoding = new byte[1 + lengthVarint.length + utf8.length];
         encoding[0] = 0x0a;
@@ -116,8 +116,7 @@ public class GcsFileInput extends InputStreamFileInput implements TransactionalF
     }
 
     // see: https://protobuf.dev/programming-guides/encoding/#varints
-    private static byte[] encodeVarint(int value)
-    {
+    private static byte[] encodeVarint(int value) {
         // utf8EncodeLength.length is up to 65535, so 2 bytes are enough for buffer
         byte[] buffer = new byte[2];
         int pos = 0;
@@ -126,8 +125,7 @@ public class GcsFileInput extends InputStreamFileInput implements TransactionalF
             value >>>= 7;
             if (value != 0) {
                 buffer[pos++] = (byte) (bits | 0x80);
-            }
-            else {
+            } else {
                 buffer[pos++] = (byte) bits;
                 break;
             }

--- a/src/main/java/org/embulk/input/gcs/GcsFileInput.java
+++ b/src/main/java/org/embulk/input/gcs/GcsFileInput.java
@@ -97,8 +97,10 @@ public class GcsFileInput extends InputStreamFileInput implements TransactionalF
         LOG.debug("path string: {} ,path length:{} \" + ", path, utf8.length);
 
         int utf8EncodeLength = utf8.length;
-        if (utf8EncodeLength >= 65_535) {
-            throw new ConfigException(String.format("last_path '%s' is too long to encode. Please try to reduce its length", path));
+        // GCP object names can be up to 1024 bytes in length.
+        // This limit aligns with task.getLastPath() expectations.
+        if (utf8EncodeLength >= 1025) {
+            throw new ConfigException(String.format("last_path '%s' is too long to encode. Maximum allowed is 1024 bytes", path));
         }
 
         lengthVarint = encodeVarint(utf8EncodeLength);

--- a/src/main/java/org/embulk/input/gcs/GcsFileInputPlugin.java
+++ b/src/main/java/org/embulk/input/gcs/GcsFileInputPlugin.java
@@ -68,7 +68,7 @@ public class GcsFileInputPlugin implements FileInputPlugin {
         // @see https://cloud.google.com/storage/docs/objects#naming
         if (task.getLastPath().isPresent()) {
             if (task.getLastPath().get().getBytes(StandardCharsets.UTF_8).length >= 1025) {
-                throw new ConfigException("last_path length is allowed up to 1024 bytes.");
+                throw new ConfigException("last_path is too long, which can contain a maximum of 1024 bytes encoded in UTF-8.");
             }
         }
 

--- a/src/main/java/org/embulk/input/gcs/GcsFileInputPlugin.java
+++ b/src/main/java/org/embulk/input/gcs/GcsFileInputPlugin.java
@@ -17,6 +17,7 @@
 package org.embulk.input.gcs;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import org.embulk.config.ConfigDiff;
@@ -64,10 +65,10 @@ public class GcsFileInputPlugin implements FileInputPlugin {
             }
         }
 
-        // @see https://cloud.google.com/storage/docs/bucket-naming
+        // @see https://cloud.google.com/storage/docs/objects#naming
         if (task.getLastPath().isPresent()) {
-            if (task.getLastPath().get().length() >= 128) {
-                throw new ConfigException("last_path length is allowed up to 127 characters");
+            if (task.getLastPath().get().getBytes(StandardCharsets.UTF_8).length >= 1025) {
+                throw new ConfigException("last_path length is allowed up to 1024 bytes.");
             }
         }
 

--- a/src/test/java/org/embulk/input/gcs/TestGcsFileInputPlugin.java
+++ b/src/test/java/org/embulk/input/gcs/TestGcsFileInputPlugin.java
@@ -394,8 +394,8 @@ public class TestGcsFileInputPlugin {
         assertEquals("CgJjMg==", GcsFileInput.base64Encode("c2"));
         assertEquals("Cgh0ZXN0LmNzdg==", GcsFileInput.base64Encode("test.csv"));
         assertEquals("ChZnY3MtdGVzdC9zYW1wbGVfMDEuY3N2", GcsFileInput.base64Encode("gcs-test/sample_01.csv"));
-        String params = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc127";
-        String expected = "Cn9jY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjMTI3";
+        String params = "ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc200";
+        String expected = "CsgBY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2MyMDA=";
         assertEquals(expected, GcsFileInput.base64Encode(params));
 
         params = "テストダミー/テス123/テストダミー/テストダミ.csv";

--- a/src/test/java/org/embulk/input/gcs/TestGcsFileInputPlugin.java
+++ b/src/test/java/org/embulk/input/gcs/TestGcsFileInputPlugin.java
@@ -31,7 +31,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -406,24 +405,21 @@ public class TestGcsFileInputPlugin {
     }
 
     @Test
-    public void testEncodeVarint() throws Exception {
-        Method encodeVarintMethod = GcsFileInput.class.getDeclaredMethod("encodeVarint", int.class);
-        encodeVarintMethod.setAccessible(true);
-
+    public void testEncodeVarint() {
         byte[] expected1 = new byte[]{0x01};
-        byte[] result1 = (byte[]) encodeVarintMethod.invoke(null, 1);
+        byte[] result1 = GcsFileInput.encodeVarint(1);
         assertArrayEquals("encodeVarint(1) should return {0x01}", expected1, result1);
 
         byte[] expected127 = new byte[]{0x7F};
-        byte[] result127 = (byte[]) encodeVarintMethod.invoke(null, 127);
+        byte[] result127 = GcsFileInput.encodeVarint(127);
         assertArrayEquals("encodeVarint(127) should return {0x7F}", expected127, result127);
 
         byte[] expected128 = new byte[]{(byte) 0x80, 0x01};
-        byte[] result128 = (byte[]) encodeVarintMethod.invoke(null, 128);
+        byte[] result128 = GcsFileInput.encodeVarint(128);
         assertArrayEquals("encodeVarint(128) should return {0x80, 0x01}", expected128, result128);
 
         byte[] expected1024 = new byte[]{(byte) 0x80, 0x08};
-        byte[] result1024 = (byte[]) encodeVarintMethod.invoke(null, 1024);
+        byte[] result1024 = GcsFileInput.encodeVarint(1024);
         assertArrayEquals("encodeVarint(1024) should return {0x80, 0x08}", expected1024, result1024);
     }
 

--- a/src/test/java/org/embulk/input/gcs/TestGcsFileInputPlugin.java
+++ b/src/test/java/org/embulk/input/gcs/TestGcsFileInputPlugin.java
@@ -406,8 +406,7 @@ public class TestGcsFileInputPlugin {
     }
 
     @Test
-    public void testEncodeVarint() throws Exception
-    {
+    public void testEncodeVarint() throws Exception {
         Method encodeVarintMethod = GcsFileInput.class.getDeclaredMethod("encodeVarint", int.class);
         encodeVarintMethod.setAccessible(true);
 

--- a/src/test/java/org/embulk/input/gcs/TestGcsFileInputPlugin.java
+++ b/src/test/java/org/embulk/input/gcs/TestGcsFileInputPlugin.java
@@ -396,7 +396,7 @@ public class TestGcsFileInputPlugin {
         assertEquals("Cgh0ZXN0LmNzdg==", GcsFileInput.base64Encode("test.csv"));
         assertEquals("ChZnY3MtdGVzdC9zYW1wbGVfMDEuY3N2", GcsFileInput.base64Encode("gcs-test/sample_01.csv"));
         String params = "ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc200";
-        String expected = "CsgBY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2MyMDA=";
+        String expected = "CsgBY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2MyMDA=";
         assertEquals(expected, GcsFileInput.base64Encode(params));
 
         params = "テストダミー/テス123/テストダミー/テストダミ.csv";


### PR DESCRIPTION
fix https://github.com/embulk/embulk-input-gcs/issues/71

# Overview
This PR updates the last_path encoding mechanism in embulk-input-gcs. Instead of using a fixed 1-byte length field (limiting paths to 127 bytes), the new implementation uses a varint length field, which can span 1–2 bytes, to represent the length of the UTF-8 encoded string.

# Why Is It Necessary?
GCP object names can be up to 1024 bytes in length. The previous implementation’s 1-byte length field restricted last_path to 128 characters, causing errors when handling longer object names. Switching to a varint length field removes this limitation and ensures that the plugin can support all valid GCP object names.